### PR TITLE
 fix tests for go1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: xenial
 sudo: required
 language: go
-go: "1.12.x"
+go: "1.13.x"
 
 services:
   - redis

--- a/rediscounter_test.go
+++ b/rediscounter_test.go
@@ -37,7 +37,13 @@ var clearRKey = flag.Bool("d", false, "clear redis key if already present")
 
 func init() {
 
-	flag.Parse()
+	// as of go 1.13 this needs to be called if intending to use flag.Parse() in init() func
+	// it will call flag.Parse() amongst other things
+	testing.Init()
+
+	if !flag.Parsed() {
+		flag.Parse()
+	}
 
 	// normalize redis address
 	envRAddr := os.Getenv("REDIS_ADDR")

--- a/webcounter/main.go
+++ b/webcounter/main.go
@@ -41,7 +41,9 @@ var htmlCounterTpl *template.Template // html template to render counter
 var htmlMetricsTpl *template.Template // html template to render metrics data
 var usageData *metrics
 
-func init() {
+// wcInit performs initialization of the global variables based on passed command line flags
+// cannot use init() as of go1.13 packages that call flag.Parse() there will cause tests to fail.
+func wcInit() {
 	flag.Parse()
 
 	// check which flags have been set
@@ -89,6 +91,8 @@ func init() {
 }
 
 func main() {
+
+	wcInit()
 
 	// initialize the server's RedisCounter instance.
 	// not done in init() as we need slightly different process for testing initialization

--- a/webcounter/main_test.go
+++ b/webcounter/main_test.go
@@ -4,6 +4,8 @@ package main
 import (
 	"flag"
 	"log"
+	"os"
+	"testing"
 
 	"github.com/go-redis/redis"
 	rediscounter "github.com/slavrd/go-redis-counter"
@@ -12,7 +14,10 @@ import (
 // commnad line flags
 var clearRKey = flag.Bool("d", false, "clear redis key if already present")
 
-func init() {
+func TestMain(m *testing.M) {
+
+	// parse command line flags
+	wcInit()
 
 	// create a redis.Client to interract with redis
 	c := redis.NewClient(&redis.Options{
@@ -41,4 +46,6 @@ func init() {
 	if err != nil {
 		log.Fatalf("error loading metrics html template: %v", err)
 	}
+
+	os.Exit(m.Run())
 }


### PR DESCRIPTION
Remove/edit calls to flag.Parse form init() funcs in regards to change in go1.13 